### PR TITLE
Insert version number into manifests

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -28,6 +28,7 @@ func publishCmd() *cobra.Command {
 }
 
 func publish(ctx context.Context, cfg *viper.Viper) error {
+	ctx = glci.WithVersion(ctx, version)
 	log.Info(ctx, "GLCI", "version", version)
 
 	flavorsCfg, publishingCfg, aliasesCfg, creds, err := loadConfigAndCredentials(ctx, cfg)

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -28,6 +28,7 @@ func removeCmd() *cobra.Command {
 }
 
 func remove(ctx context.Context, cfg *viper.Viper) error {
+	ctx = glci.WithVersion(ctx, version)
 	log.Info(ctx, "GLCI", "version", version)
 
 	flavorsCfg, publishingCfg, _, creds, err := loadConfigAndCredentials(ctx, cfg)

--- a/internal/gl/gardenlinux.go
+++ b/internal/gl/gardenlinux.go
@@ -13,6 +13,7 @@ const (
 type Manifest struct {
 	Version                string          `yaml:"version"`
 	BuildCommittish        string          `yaml:"build_committish"`
+	GLCIVersion            *string         `yaml:"glci_version,omitempty"`
 	Architecture           Architecture    `yaml:"architecture"`
 	Platform               string          `yaml:"platform"`
 	Modifiers              []string        `yaml:"modifiers"`

--- a/internal/glci/config.go
+++ b/internal/glci/config.go
@@ -1,6 +1,7 @@
 package glci
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/gardenlinux/glci/internal/cloudprovider"
@@ -73,6 +74,11 @@ func (c *PublishingConfig) Validate() error {
 	return nil
 }
 
+// WithVersion stores the GLCI version string into the context.
+func WithVersion(ctx context.Context, version string) context.Context {
+	return context.WithValue(ctx, ctxkVer{}, version)
+}
+
 type cfgFlavor struct {
 	Platform string `mapstructure:"platform"`
 	Cname    string `mapstructure:"cname"`
@@ -95,4 +101,11 @@ type AliasesConfig map[string][]string
 // Validate ensures that the aliases configuration is valid.
 func (*AliasesConfig) Validate() error {
 	return nil
+}
+
+type ctxkVer struct{}
+
+func glciVersion(ctx context.Context) string {
+	ver, _ := ctx.Value(ctxkVer{}).(string) //nolint:revive // An invalid or missing version results in an empty string.
+	return ver
 }

--- a/internal/glci/glci.go
+++ b/internal/glci/glci.go
@@ -120,6 +120,10 @@ func Publish(ctx context.Context, flavorsConfig FlavorsConfig, publishingConfig 
 			return fmt.Errorf("cannot add publishing output for %s: %w", publication.Cname, err)
 		}
 		publication.Manifest.PublishedImageMetadata = manifestOutput
+		glciVer := glciVersion(ctx)
+		if glciVer != "" {
+			publication.Manifest.GLCIVersion = &glciVer
+		}
 
 		log.Info(lctx, "Updating manifest")
 		manifestKey := fmt.Sprintf("meta/singles/%s-%s-%.8s", publication.Cname, version, commit)
@@ -246,6 +250,10 @@ func Remove(ctx context.Context, flavorsConfig FlavorsConfig, publishingConfig P
 			return fmt.Errorf("cannot remove publishing output for %s: %w", publication.Cname, err)
 		}
 		publication.Manifest.PublishedImageMetadata = manifestOutput
+		glciVer := glciVersion(ctx)
+		if glciVer != "" {
+			publication.Manifest.GLCIVersion = &glciVer
+		}
 
 		log.Info(lctx, "Updating manifest")
 		manifestKey := fmt.Sprintf("meta/singles/%s-%s-%.8s", publication.Cname, version, commit)


### PR DESCRIPTION
**What this PR does / why we need it**:
Insert version number into manifests

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Insert version number into manifests
```
