### PR TITLE
Automatically detect if publishing to China

### DIFF
--- a/glci.yaml
+++ b/glci.yaml
@@ -59,16 +59,13 @@ publishing:
     config: gardenlinux
     bucket: gardenlinux-community
   - type: AWS
-    targets:
     source: S3
     config: gardenlinux
     image_tags:
       static_tags:
         sec-by-def-public-image-exception: enabled
   - type: AWS
-    targets:
     source: S3-China
-    cloud: China
     config: gardenlinux-cn
     image_tags:
       static_tags:
@@ -80,7 +77,6 @@ publishing:
     gallery_config: gardenlinux-community-gallery-nvme
   - type: Azure
     source: S3-China
-    cloud: China
     storage_account_config: gardenlinux-community-gallery-cn
     service_principal_config: gardenlinux-cn
     gallery_config: gardenlinux-community-gallery-nvme-cn

--- a/internal/cloudprovider/aws.go
+++ b/internal/cloudprovider/aws.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"slices"
+	"strings"
 	"time"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
@@ -91,15 +92,8 @@ func (p *aws) SetTargetConfig(ctx context.Context, cfg map[string]any, sources m
 		return fmt.Errorf("missing credentials config %s", p.pubCfg.Config)
 	}
 
-	p.pubCfg.china = false
-	if p.pubCfg.Cloud != nil {
-		switch *p.pubCfg.Cloud {
-		case "China":
-			p.pubCfg.china = true
-		case "":
-		default:
-			return fmt.Errorf("unknown cloud %s", *p.pubCfg.Cloud)
-		}
+	if strings.HasPrefix(creds.Region, "cn-") {
+		p.pubCfg.china = true
 	}
 
 	if p.pubCfg.Regions != nil {
@@ -459,7 +453,6 @@ type awsSourceConfig struct {
 
 type awsPublishingConfig struct {
 	Source    string        `mapstructure:"source"`
-	Cloud     *string       `mapstructure:"cloud,omitempty"`
 	Config    string        `mapstructure:"config"`
 	Regions   *[]string     `mapstructure:"regions,omitempty"`
 	ImageTags *awsImageTags `mapstructure:"image_tags,omitempty"`

--- a/internal/cloudprovider/azure.go
+++ b/internal/cloudprovider/azure.go
@@ -109,20 +109,14 @@ func (p *azure) SetTargetConfig(_ context.Context, cfg map[string]any, sources m
 		return fmt.Errorf("missing service principal credentials config %s", p.pubCfg.ServicePrincipalConfig)
 	}
 
-	_, ok = p.galleryCreds[p.pubCfg.GalleryConfig]
+	var gcreds azureGalleryCredentials
+	gcreds, ok = p.galleryCreds[p.pubCfg.GalleryConfig]
 	if !ok {
 		return fmt.Errorf("missing gallery credentials config %s", p.pubCfg.GalleryConfig)
 	}
 
-	p.pubCfg.china = false
-	if p.pubCfg.Cloud != nil {
-		switch *p.pubCfg.Cloud {
-		case "China":
-			p.pubCfg.china = true
-		case "":
-		default:
-			return fmt.Errorf("unknown cloud %s", *p.pubCfg.Cloud)
-		}
+	if strings.HasPrefix(gcreds.Region, "china") {
+		p.pubCfg.china = true
 	}
 
 	apiEndpoint := "core.windows.net"
@@ -497,7 +491,6 @@ type azureGalleryCredentials struct {
 
 type azurePublishingConfig struct {
 	Source                 string    `mapstructure:"source"`
-	Cloud                  *string   `mapstructure:"cloud,omitempty"`
 	StorageAccountConfig   string    `mapstructure:"storage_account_config"`
 	ServicePrincipalConfig string    `mapstructure:"service_principal_config"`
 	GalleryConfig          string    `mapstructure:"gallery_config"`


### PR DESCRIPTION
**What this PR does / why we need it**:
Whether a certain target published to China can be detected from credentials and does not need to be specified in the configuration.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Automatically detect if publishing to China
```
