### PR TITLE
Add steamroller mode to removal

### DIFF
--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -23,6 +23,7 @@ func removeCmd() *cobra.Command {
 	c.Flags().String("credentials-base64", "", "base64 encoded credentials YAML (overrides --credentials-file)")
 	c.Flags().StringP("version", "v", "", "release version")
 	c.Flags().StringP("commit", "c", "", "release commit(ish)")
+	c.Flags().Bool("steamroll", false, "ignore errors while destroying things")
 
 	return c
 }
@@ -36,5 +37,5 @@ func remove(ctx context.Context, cfg *viper.Viper) error {
 	}
 
 	//nolint:wrapcheck // Directly wraps the GLCI command.
-	return glci.Remove(ctx, flavorsCfg, publishingCfg, creds, cfg.GetString("version"), cfg.GetString("commit"))
+	return glci.Remove(ctx, flavorsCfg, publishingCfg, creds, cfg.GetString("version"), cfg.GetString("commit"), cfg.GetBool("steamroll"))
 }

--- a/glci_dev.yaml
+++ b/glci_dev.yaml
@@ -99,3 +99,4 @@ aliases:
   python3-jwt: [ PyJWT ]
   python3-markupsafe: [ MarkupSafe ]
 omit-component-descriptor: true
+steamroll: true

--- a/internal/cloudprovider/cloudprovider.go
+++ b/internal/cloudprovider/cloudprovider.go
@@ -39,7 +39,7 @@ type PublishingTarget interface {
 	AddOwnPublishingOutput(output, own PublishingOutput) (PublishingOutput, error)
 	RemoveOwnPublishingOutput(output PublishingOutput) (PublishingOutput, error)
 	Publish(ctx context.Context, cname string, manifest *gl.Manifest, sources map[string]ArtifactSource) (PublishingOutput, error)
-	Remove(ctx context.Context, manifest *gl.Manifest, sources map[string]ArtifactSource) error
+	Remove(ctx context.Context, manifest *gl.Manifest, sources map[string]ArtifactSource, steamroll bool) error
 }
 
 // OCMTarget is a target onto which GLCI can publish an OCM component descriptor.

--- a/internal/cloudprovider/fake.go
+++ b/internal/cloudprovider/fake.go
@@ -91,7 +91,7 @@ func (p *fake) Publish(_ context.Context, _ string, _ *gl.Manifest, _ map[string
 	return p, nil
 }
 
-func (*fake) Remove(_ context.Context, _ *gl.Manifest, _ map[string]ArtifactSource) error {
+func (*fake) Remove(_ context.Context, _ *gl.Manifest, _ map[string]ArtifactSource, _ bool) error {
 	return nil
 }
 

--- a/internal/glci/remove.go
+++ b/internal/glci/remove.go
@@ -12,6 +12,7 @@ import (
 
 // Remove removes a release from all cloud providers specified in the flavors and publishing configurations.
 func Remove(ctx context.Context, flavorsConfig FlavorsConfig, publishingConfig PublishingConfig, creds Credentials, version, commit string,
+	steamroll bool,
 ) error {
 	ctx = log.WithValues(ctx, "op", "remove", "version", version, "commit", commit)
 
@@ -93,7 +94,7 @@ func Remove(ctx context.Context, flavorsConfig FlavorsConfig, publishingConfig P
 		}
 
 		log.Info(lctx, "Removing image")
-		err = publication.Target.Remove(lctx, publication.Manifest, sources)
+		err = publication.Target.Remove(lctx, publication.Manifest, sources, steamroll)
 		if err != nil {
 			return fmt.Errorf("cannot remove %s from %s: %w", publication.Cname, publication.Target.Type(), err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
By default removing images is designed to succeed only if the state of the images is exactly as expected. In steamroller mode GLCI will ignore missing images in order to have a better chance of succeeding. This is useful for cleaning up after a partial publishing.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add steamroller mode to removal
```
