### PR TITLE
Add File OCMTarget

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,6 +31,11 @@ linters:
   - wsl
   - wsl_v5
   settings:
+    gosec:
+      config:
+        G301: "0755"
+        G302: "0644"
+        G306: "0644"
     govet:
       enable-all: true
       disable:

--- a/glci_dev.yaml
+++ b/glci_dev.yaml
@@ -88,9 +88,10 @@ publishing:
     hypervisor: VMware
     regions: [ eu-nl-1 ]
   ocm:
-    type: OCI
+    type: File
     config: ar-gardenlinux-test
     repository: europe-docker.pkg.dev/sap-se-gcp-gardenlinux/tests
+    file: descriptor.yaml
 aliases:
   auditd: [ audit ]
   libc-bin: [ glibc ]

--- a/internal/cloudprovider/cloudprovider.go
+++ b/internal/cloudprovider/cloudprovider.go
@@ -48,6 +48,7 @@ type OCMTarget interface {
 	SetCredentials(credentials map[string]any) error
 	SetOCMConfig(ctx context.Context, config map[string]any) error
 	Close() error
+	OCMType() string
 	OCMRepository() string
 	PublishComponentDescriptor(ctx context.Context, version string, descriptor []byte) error
 }

--- a/internal/cloudprovider/fake.go
+++ b/internal/cloudprovider/fake.go
@@ -95,6 +95,10 @@ func (*fake) Remove(_ context.Context, _ *gl.Manifest, _ map[string]ArtifactSour
 	return nil
 }
 
+func (*fake) OCMType() string {
+	return "Fake"
+}
+
 func (*fake) OCMRepository() string {
 	return "fake"
 }

--- a/internal/cloudprovider/file.go
+++ b/internal/cloudprovider/file.go
@@ -1,0 +1,77 @@
+package cloudprovider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/gardenlinux/glci/internal/log"
+)
+
+func init() {
+	registerOCMTarget(func() OCMTarget {
+		return &file{}
+	})
+}
+
+func (*file) Type() string {
+	return "File"
+}
+
+func (*file) SetCredentials(_ map[string]any) error {
+	return nil
+}
+
+func (p *file) SetOCMConfig(_ context.Context, cfg map[string]any) error {
+	err := setConfig(cfg, &p.fileCfg)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (*file) Close() error {
+	return nil
+}
+
+func (*file) OCMType() string {
+	t, err := NewOCMTarget("OCI")
+	if err != nil {
+		return ""
+	}
+	return t.OCMType()
+}
+
+func (p *file) OCMRepository() string {
+	return p.fileCfg.Repository
+}
+
+func (p *file) PublishComponentDescriptor(ctx context.Context, _ string, descriptor []byte) error {
+	if !p.isConfigured() {
+		return errors.New("config not set")
+	}
+	ctx = log.WithValues(ctx, "repo", p.fileCfg.File)
+
+	log.Debug(ctx, "Writing file", "file", p.fileCfg.File)
+	err := os.WriteFile(p.fileCfg.File, descriptor, 0o644)
+	if err != nil {
+		return fmt.Errorf("cannot write file %s: %w", p.fileCfg.File, err)
+	}
+
+	return nil
+}
+
+type file struct {
+	fileCfg fileOCMConfig
+}
+
+type fileOCMConfig struct {
+	File       string `mapstructure:"file"`
+	Repository string `mapstructure:"repository"`
+}
+
+func (p *file) isConfigured() bool {
+	return p.fileCfg.File != ""
+}

--- a/internal/cloudprovider/oci.go
+++ b/internal/cloudprovider/oci.go
@@ -13,7 +13,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	specv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
-	"oras.land/oras-go/v2/content/file"
+	orasfile "oras.land/oras-go/v2/content/file"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/retry"
@@ -74,6 +74,10 @@ func (*oci) Close() error {
 	return nil
 }
 
+func (*oci) OCMType() string {
+	return "OCIRegistry"
+}
+
 func (p *oci) OCMRepository() string {
 	return p.ociCfg.Repository
 }
@@ -122,8 +126,8 @@ func (p *oci) PublishComponentDescriptor(ctx context.Context, version string, de
 	}()
 
 	log.Debug(ctx, "Creating local OCI store", "dir", tmpDir)
-	var fs *file.Store
-	fs, err = file.New(tmpDir)
+	var fs *orasfile.Store
+	fs, err = orasfile.New(tmpDir)
 	if err != nil {
 		return fmt.Errorf("cannot create local OCI store in %s: %w", tmpDir, err)
 	}

--- a/internal/ocm/ocm.go
+++ b/internal/ocm/ocm.go
@@ -44,7 +44,7 @@ func BuildComponentDescriptor(ctx context.Context, source cloudprovider.Artifact
 			Provider:     componentProvider,
 			RepositoryContexts: []componentDescriptorRepositoryContext{
 				{
-					Type:    "OCIRegistry",
+					Type:    ocmTarget.OCMType(),
 					BaseURL: ocmTarget.OCMRepository(),
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a new OCMTarget that writes the component descriptor to a local file, and make it default for development. The File OCMTarget "fakes" being a OCI repository because the OCM spec does not. have a File storage type.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add File OCMTarget
```
