### PR TITLE
Update openstack.go

### DIFF
--- a/internal/cloudprovider/openstack.go
+++ b/internal/cloudprovider/openstack.go
@@ -411,7 +411,7 @@ func (*openstack) createImage(ctx context.Context, imageClient *gophercloud.Serv
 			"vmware_disktype":           "streamOptimized",
 			"vmware_ostype":             "debian10_64Guest",
 		}
-		visibility = images.ImageVisibilityPrivate
+		visibility = images.ImageVisibilityPublic
 	case openstackVariantMetal:
 		properties = map[string]string{
 			"hypervisor_type":  "baremetal",


### PR DESCRIPTION
MAOSIPA!

**What this PR does / why we need it**:
Because public openstack images should be public!